### PR TITLE
fix: upgrade to 1.3.9-beta.5

### DIFF
--- a/SahhaReactNative.podspec
+++ b/SahhaReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency 'Sahha', '1.3.9-beta.4'
+  s.dependency 'Sahha', '1.3.9-beta.5'
 
 
   install_modules_dependencies(s)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,5 +76,5 @@ dependencies {
   implementation "com.facebook.react:react-native:0.83.1"  // Pinned to your RN version
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.google.code.gson:gson:2.13.2"
-  implementation "ai.sahha.android:sahha-api:1.3.9-beta.4"
+  implementation "ai.sahha.android:sahha-api:1.3.9-beta.5"
 }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -36,5 +36,25 @@ target 'SahhaReactNativeExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Xcode 26 / new clang rejects fmt 11.0.2's consteval format-string checks
+    # ("call to consteval function ... is not a constant expression"). fmt's
+    # base.h sets FMT_USE_CONSTEVAL with no #ifndef guard, so a -D flag is
+    # clobbered — patch the header to force it off. Idempotent and re-applied on
+    # every pod install. Local example-app workaround; not part of the shipped SDK.
+    fmt_base = File.join(__dir__, 'Pods', 'fmt', 'include', 'fmt', 'base.h')
+    if File.exist?(fmt_base)
+      marker = '// sahha: FMT_USE_CONSTEVAL disabled for Xcode 26 compatibility'
+      contents = File.read(fmt_base)
+      unless contents.include?(marker)
+        contents = contents.sub(
+          "#if FMT_USE_CONSTEVAL",
+          "#{marker}\n#undef FMT_USE_CONSTEVAL\n#define FMT_USE_CONSTEVAL 0\n#if FMT_USE_CONSTEVAL"
+        )
+        File.chmod(0644, fmt_base) # pod sources are installed read-only
+        File.write(fmt_base, contents)
+        Pod::UI.puts "[sahha] Patched fmt base.h: FMT_USE_CONSTEVAL=0 (Xcode 26 workaround)".green
+      end
+    end
   end
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2707,8 +2707,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Sahha (1.3.9-beta.3)
-  - SahhaReactNative (1.3.9-beta.3):
+  - Sahha (1.3.9-beta.5)
+  - SahhaReactNative (1.3.9-beta.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2734,7 +2734,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Sahha (= 1.3.9-beta.3)
+    - Sahha (= 1.3.9-beta.5)
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
@@ -3087,11 +3087,11 @@ SPEC CHECKSUMS:
   RNCPicker: bf95ec4b2483e2ab256047130bc536b437cd916c
   RNDateTimePicker: 73ffdd45f0ce1d00ff981031679a05206e619fdc
   RNScreens: 714e10b6b554f7dc7ad9f78dcf36dc8e3fc73415
-  Sahha: 2675f297c93bb2392030ee5b86875fd0b13bc642
-  SahhaReactNative: e2b058213cf3b32bbe4968fc91c7df4c9b52b68b
+  Sahha: 0668158530e539ad83a8fa98d5ce5d2edcf541cb
+  SahhaReactNative: 231f728fb0e1626d816344d4c2161b4c46d5b6a4
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 5456bb010373068fc92221140921b09d126b116e
 
-PODFILE CHECKSUM: ffe0c3c4c1f21363070f1c97db069c1366401f47
+PODFILE CHECKSUM: 97fa7620f87ea30cf1e3e249a5ff07919a12af9f
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sahha-react-native",
-  "version": "1.3.9-beta.4",
+  "version": "1.3.9-beta.5",
   "description": "Sahha React Native SDK",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
## Summary

Upgrades the native Sahha SDK references and the package to `1.3.9-beta.5`, and patches the example app so it builds under Xcode 26.5.

### Added

_None._

### Changed

- Bump iOS `Sahha` pod and Android `sahha-api` references to `1.3.9-beta.5`
- Bump package version to `1.3.9-beta.5`

### Fixed

- Patch fmt's `consteval` format-string checks (force `FMT_USE_CONSTEVAL 0`) in the example `Podfile` so it compiles under Xcode 26.5 / new clang. fmt 11.0.2 (via RCT-Folly) otherwise fails with *"call to consteval function ... is not a constant expression"*. Example-only — not part of the published package.