### PR TITLE
fix: upgrade to 1.3.9

### DIFF
--- a/SahhaReactNative.podspec
+++ b/SahhaReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency 'Sahha', '1.3.9-beta.5'
+  s.dependency 'Sahha', '1.3.9'
 
 
   install_modules_dependencies(s)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,5 +76,5 @@ dependencies {
   implementation "com.facebook.react:react-native:0.83.1"  // Pinned to your RN version
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.google.code.gson:gson:2.13.2"
-  implementation "ai.sahha.android:sahha-api:1.3.9-beta.5"
+  implementation "ai.sahha.android:sahha-api:1.3.9"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2707,8 +2707,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Sahha (1.3.9-beta.5)
-  - SahhaReactNative (1.3.9-beta.5):
+  - Sahha (1.3.9)
+  - SahhaReactNative (1.3.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -2734,7 +2734,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Sahha (= 1.3.9-beta.5)
+    - Sahha (= 1.3.9)
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
@@ -3087,8 +3087,8 @@ SPEC CHECKSUMS:
   RNCPicker: bf95ec4b2483e2ab256047130bc536b437cd916c
   RNDateTimePicker: 73ffdd45f0ce1d00ff981031679a05206e619fdc
   RNScreens: 714e10b6b554f7dc7ad9f78dcf36dc8e3fc73415
-  Sahha: 0668158530e539ad83a8fa98d5ce5d2edcf541cb
-  SahhaReactNative: 231f728fb0e1626d816344d4c2161b4c46d5b6a4
+  Sahha: 80053864fedde618e438149b9bacd77741887052
+  SahhaReactNative: f5a2f35d875d64b5359bb6a0d40f50a45c591b81
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 5456bb010373068fc92221140921b09d126b116e
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sahha-react-native",
-  "version": "1.3.9-beta.5",
+  "version": "1.3.9",
   "description": "Sahha React Native SDK",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
## Summary

Upgrades the native Sahha SDK references and the package from `1.3.9-beta.5` to the stable **`1.3.9`** release.

### Added

_None._

### Changed

- Upgraded the native Sahha SDK to 1.3.9 (Android and iOS).

### Fixed

_None._