### PR TITLE
docs: note that enableSensors waits on the health permissions sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,18 @@ Sahha.enableSensors(
 );
 ```
 
+> [!IMPORTANT]
+> `enableSensors` is a long-running call. The first time it runs, the OS presents the
+> health permissions sheet, and the callback does not fire until the user responds —
+> which can legitimately take a minute or more when many sensors are requested. Call it
+> while the app is active (foregrounded) so the sheet can present, and avoid racing the
+> callback against a short client-side timeout. The callback is guaranteed to settle:
+> on iOS the native authorization request times out after 120 seconds, and the React
+> Native bridge adds a 150-second watchdog as a backstop. If you add your own timeout on
+> top, make it longer than 150 seconds, and treat it as a cue to re-check
+> `getSensorStatus(...)` rather than as a failure — the user may simply still be reading
+> the permissions sheet.
+
 ---
 
 ### getScores(...)


### PR DESCRIPTION
Documents that `enableSensors` is long-running: the callback does not fire until the user responds to the health permissions sheet, so apps should not race it against short client-side timeouts (a customer-side 15s abort is how the recent hang report surfaced).

States the guarantees now in place — the native 120s authorization timeout (sahha-ios 1.4.0-beta.1) and the 150s bridge watchdog (#77) — and recommends re-checking `getSensorStatus` on any app-level timeout instead of treating it as a failure.