### PR TITLE
fix: upgrade to 1.4.0-beta.2

### DIFF
--- a/SahhaReactNative.podspec
+++ b/SahhaReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency 'Sahha', '1.4.0-beta.1'
+  s.dependency 'Sahha', '1.4.0-beta.2'
 
 
   install_modules_dependencies(s)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,5 +76,5 @@ dependencies {
   implementation "com.facebook.react:react-native:0.83.1"  // Pinned to your RN version
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.google.code.gson:gson:2.13.2"
-  implementation "ai.sahha.android:sahha-api:1.4.0-beta.1"
+  implementation "ai.sahha.android:sahha-api:1.4.0-beta.2"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2707,8 +2707,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Sahha (1.4.0-beta.1)
-  - SahhaReactNative (1.4.0-beta.1):
+  - Sahha (1.4.0-beta.2)
+  - SahhaReactNative (1.4.0-beta.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2734,7 +2734,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Sahha (= 1.4.0-beta.1)
+    - Sahha (= 1.4.0-beta.2)
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
@@ -3087,8 +3087,8 @@ SPEC CHECKSUMS:
   RNCPicker: bf95ec4b2483e2ab256047130bc536b437cd916c
   RNDateTimePicker: 73ffdd45f0ce1d00ff981031679a05206e619fdc
   RNScreens: 714e10b6b554f7dc7ad9f78dcf36dc8e3fc73415
-  Sahha: 62e9ceca5431682ddfc55fd5768ebf8c63e84e3f
-  SahhaReactNative: db450dbc86d143085d723568684d41da8132ab18
+  Sahha: 4c76bc33ab9e1e1e6f7800e3b400c8887df96961
+  SahhaReactNative: f37fabfd41c7afa3676095a206c6ba3885505140
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 5456bb010373068fc92221140921b09d126b116e
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sahha-react-native",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "Sahha React Native SDK",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
## Summary

Upgrades the native Sahha SDK references (iOS pod and Android `sahha-api` Maven dependency) from `1.4.0-beta.1` to **`1.4.0-beta.2`** and bumps the package version to match. Regenerates the example Podfile.lock.

### Added

_None._

### Changed

- Upgraded the native Sahha SDK to 1.4.0-beta.2 (Android and iOS).

### Fixed

- Android: `getSamples` no longer consumes the steps upload dedupe state, so step samples queried after an upload window are returned correctly (sahha-android-sdk v1.4.0-beta.2).
- iOS: corrected the CocoaPods pod name in the install instructions (sahha-ios 1.4.0-beta.2).