### PR TITLE
chore: point the CI build step at yarn prepare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build package
-        run: yarn prepack
+        run: yarn prepare


### PR DESCRIPTION
The RN 0.81 template regeneration renamed the package build script from `prepack` to `prepare`, but the CI build job still runs `yarn prepack`, which fails under yarn 3 as an unknown script (seen on the #81 release PR checks). Points the build step at the script that exists.