### PR TITLE
chore: pin conventional-changelog-angular v8 at the root

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/jest": "^29.5.14",
     "@types/react": "^19.1.0",
     "commitlint": "^19.8.1",
+    "conventional-changelog-angular": "^8.1.0",
     "del-cli": "^6.0.0",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11234,6 +11234,7 @@ __metadata:
     "@types/jest": ^29.5.14
     "@types/react": ^19.1.0
     commitlint: ^19.8.1
+    conventional-changelog-angular: ^8.1.0
     del-cli: ^6.0.0
     eslint: ^9.35.0
     eslint-config-prettier: ^10.1.8


### PR DESCRIPTION
Fixes `yarn release` crashing with `whatBump is not a function`: the Dependabot dev-dependency refresh (#79) let `@commitlint/parse`'s `conventional-changelog-angular@7` win the root node_modules hoist, so `@release-it/conventional-changelog`'s preset loader resolved the old preset format (no flat `whatBump`). Pinning `^8.1.0` as a root devDependency restores the hoist release-it needs, while commitlint keeps its nested v7 (verified: release-it dry run passes the changelog stage, and commitlint still validates commit messages via lefthook).